### PR TITLE
Fixing change to looting api limit params to match idle game

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
         const totalByDayRent = {}
 
         requests = []
-        requests.push(fetch(`https://idle-api.crabada.com/public/idle/mines?looter_address=${wallet}&limit=20&status=close`).then(response => response.json()))
+        requests.push(fetch(`https://idle-api.crabada.com/public/idle/mines?looter_address=${wallet}&limit=8&status=close`).then(response => response.json()))
         requests.push(fetch(`https://idle-api.crabada.com/public/idle/mines?user_address=${wallet}&status=close&limit=20`).then(response => response.json()))
         requests.push(fetch(`https://idle-api.crabada.com/public/idle/crabadas/out-game?user_address=${wallet}&order=desc&limit=50`).then(response => response.json()))
         requests.push(fetch(`https://idle-api.crabada.com/public/idle/crabadas/for-lending?user_address=${wallet}&limit=50`).then(response => response.json()))


### PR DESCRIPTION
Change is needed to make the revenue statistics github pages site work. Change matches ui input